### PR TITLE
libmusl compatibility

### DIFF
--- a/src/lagscope.h
+++ b/src/lagscope.h
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <sys/types.h>
 
 #include "const.h"
 #include "logger.h"


### PR DESCRIPTION
Added <sys/types.h> so it compiles in Alpine Linux (libmusl based). Otherwise you get this error:

gcc -Wall -W -O2 -fno-strict-aliasing -c lagscope.c -o lagscope.o
In file included from lagscope.c:7:0:
lagscope.h:29:2: error: unknown type name 'uint'
  uint    server_port;         /* '-p' for server listening base port */
  ^~~~
make: *** [Makefile:10: lagscope.o] Error 1


After including types.h:

/lagscope/src # make
gcc -Wall -W -O2 -fno-strict-aliasing -c lagscope.c -o lagscope.o
gcc -Wall -W -O2 -fno-strict-aliasing -c tcpstream.c -o tcpstream.o
gcc -Wall -W -O2 -fno-strict-aliasing -c controller.c -o controller.o
gcc -Wall -W -O2 -fno-strict-aliasing -c util.c -o util.o
gcc -Wall -W -O2 -fno-strict-aliasing -c main.c -o main.o
gcc -Wall -W -O2 -fno-strict-aliasing -pthread -o lagscope lagscope.o tcpstream.o controller.o util.o  main.o
/lagscope/src # ./lagscope
lagscope 0.1.1
---------------------------------------------------------
11:07:40 INFO: no role specified; use receiver role
^C11:07:41 INFO: Interrupted by Ctrl+C