### PR TITLE
Makefile Cleanup

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ CC=gcc
 CFLAGS=-Wall -W -O2 -fno-strict-aliasing
 CLIBS=-pthread
 OUT=lagscope
-OBJS=lagscope.o tcpstream.o controller.o util.o  main.o
+OBJS=lagscope.o tcpstream.o controller.o util.o main.o
 
 $(OUT): lagscope.o tcpstream.o controller.o util.o main.o
 	$(CC) $(CFLAGS) $(CLIBS) -o $(OUT) $(OBJS)
@@ -25,4 +25,3 @@ clean:
 .PHONY: install
 install:
 	cp $(OUT) /usr/bin
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,9 +19,12 @@ main.o: main.c
 
 .PHONY: clean
 clean:
-	rm -rf /usr/bin/$(OUT)
 	rm -rf *.o $(OUT)
 
 .PHONY: install
 install:
 	cp $(OUT) /usr/bin
+
+.PHONY: uninstall
+uninstall:
+	rm -rf /usr/bin/$(OUT)


### PR DESCRIPTION
Move system binary removal to its own sub command as this usually requires escalated privileges
Remove extra space
Remove extra newline at end of file