### PR TITLE
Remove dependancy on C++ packages

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-project (Lagscope)
+project (Lagscope C)
 file(GLOB CSources *.c)
 add_executable(lagscope ${CSources})
 if(UNIX)


### PR DESCRIPTION
Cmake by default looks for C & C++ compilers if not specified any.
In this PR we specify C.