### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ On NODE1 (the receiver), run:
 
 On NODE2 (the sender), run:
 ```
-./lagscope -s192.168.4.1 -H -a 10 -l 1 -c 98
+./lagscope -s192.168.4.1 -H -a10 -l1 -c98
 ```
 (Translation: Run lagscope as a sender, with default test settings; report histogram value with customized factors.)
 
@@ -71,7 +71,7 @@ On NODE2 (the sender), run:
 Example sender-side output from a given run:
 
 ```
-simonxiao@NODE2:~/lagscope/src# ./lagscope -s192.168.4.1 -H -a 10 -l 1 -c 98
+simonxiao@NODE2:~/lagscope/src# ./lagscope -s192.168.4.1 -H -a10 -l1 -c98
 lagscope 0.1.1
 ---------------------------------------------------------
 13:19:44 INFO: New connection: local:13948 [socket:3] --> 192.168.4.1:6001

--- a/src/common.h
+++ b/src/common.h
@@ -38,7 +38,6 @@
 #define WSACLEAN() WSACleanup()
 #define SLEEP(t) Sleep(t*1000)
 #define run_test_timer(duration) SetTimer(NULL, 0, duration*1000, (TIMERPROC) timer_fired)
-int gettimeofday(struct timeval * tp, struct timezone * tzp);
 int asprintf(char **strp, const char *format, ...);
 char* optarg;
 int getopt(int argc, char *const argv[], const char *optstr);

--- a/src/lagscope.h
+++ b/src/lagscope.h
@@ -64,8 +64,8 @@ struct lagscope_test_client{
 
 struct lagscope_test_runtime{
 	struct lagscope_test *test;
-	struct timeval start_time;
-	struct timeval current_time;
+	long long start_time;
+	long long current_time;
 	unsigned long  ping_elapsed;
 
 	unsigned long lazy_prog_report_factor;

--- a/src/lin_utils.c
+++ b/src/lin_utils.c
@@ -2,6 +2,13 @@
 #include "controller.h"
 
 #ifndef _WIN32
+long long time_in_usec(void)
+{
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	return (1000000 * tv.tv_sec + tv.tv_usec);
+}
+
 void run_test_timer(int duration)
 {
 	struct itimerval it_val;

--- a/src/util.c
+++ b/src/util.c
@@ -96,14 +96,16 @@ void print_usage()
 	printf("\treceiver:\n");
 	printf("\t1) ./lagscope -r\n");
 	printf("\t2) ./lagscope -r192.168.1.1\n");
-	printf("\t3) ./lagscope -r -D -f0 -6 -p 6789 -V\n");
+	printf("\t3) ./lagscope -r -D -f0 -6 -p6789 -V\n");
 	printf("\tsender:\n");
 	printf("\t1) ./lagscope -s192.168.1.1\n");
-	printf("\t2) ./lagscope -s192.168.1.1 -t 600 -i 1 -V\n");
-	printf("\t3) ./lagscope -s192.168.1.1 -n 1000 -6 -i 2 -V\n");
-	printf("\t1) ./lagscope -s192.168.1.1 -H -a 10 -l 1 -c 98\n");
+	printf("\t2) ./lagscope -s192.168.1.1 -t600 -i1 -V\n");
+	printf("\t3) ./lagscope -s192.168.1.1 -n1000 -6 -i2 -V\n");
+	printf("\t1) ./lagscope -s192.168.1.1 -H -a10 -l1 -c98\n");
 	printf("\t1) ./lagscope -s192.168.1.1 -Pfreq_table.json\n");
 	printf("\t1) ./lagscope -s192.168.1.1 -Rraw_latency_values.csv\n");
+
+	printf("\nNote: There should be no space between option and its value\n");
 }
 
 void print_version()

--- a/src/util.h
+++ b/src/util.h
@@ -31,10 +31,7 @@ void latencies_stats_cleanup(void);
 double unit_atod(const char *s);
 char *retrive_ip_address_str(struct sockaddr_storage *ss, char *ip_str, size_t maxlen);
 
-static inline double get_time_diff(struct timeval *t1, struct timeval *t2)
-{
-	return fabs((t1->tv_sec + (t1->tv_usec / 1000000.0)) - (t2->tv_sec + (t2->tv_usec / 1000000.0)));
-}
+long long time_in_usec(void);
 
 static inline void report_progress(struct lagscope_test_runtime *test_runtime)
 {
@@ -51,10 +48,10 @@ static inline void report_progress(struct lagscope_test_runtime *test_runtime)
 		test_runtime->ping_elapsed * 100 / test_runtime->test->iteration);
 	}
 	else {
-		double time_elapsed = get_time_diff(&test_runtime->current_time, &test_runtime->start_time);
-		printf("%s: %.0f%% completed.\r",
+		long long time_elapsed = test_runtime->current_time - test_runtime->start_time;
+		printf("%s: %lld%% completed.\r",
 		test_runtime->test->bind_address,
-		time_elapsed * 100 / test_runtime->test->duration);
+		time_elapsed / 10000 / test_runtime->test->duration);
 	}
 	fflush(stdout);
 }

--- a/src/win_utils.c
+++ b/src/win_utils.c
@@ -26,22 +26,16 @@ int getopt(int argc, char *const argv[], const char *optstr)
 	return opt;
 }
 
-int gettimeofday(struct timeval * tp, struct timezone * tzp)
+long long time_in_usec(void)
 {
-	static const uint64_t EPOCH = ((uint64_t) 116444736000000000ULL);
+	LARGE_INTEGER Time, Frequency;
 
-	SYSTEMTIME  system_time;
-	FILETIME    file_time;
-	uint64_t    time;
+	QueryPerformanceFrequency(&Frequency);
+	QueryPerformanceCounter(&Time);
 
-	GetSystemTime( &system_time );
-	SystemTimeToFileTime( &system_time, &file_time );
-	time =  ((uint64_t)file_time.dwLowDateTime );
-	time += ((uint64_t)file_time.dwHighDateTime) << 32;
-
-	tp->tv_sec  = (long) ((time - EPOCH) / 10000000L);
-	tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
-        return 0;
+	Time.QuadPart *= 1000000;
+	Time.QuadPart /= Frequency.QuadPart;
+	return (Time.QuadPart);
 }
 
 static int vasprintf(char **strp, const char *format, va_list ap)

--- a/src/win_utils.c
+++ b/src/win_utils.c
@@ -19,7 +19,7 @@ int getopt(int argc, char *const argv[], const char *optstr)
 	if (p[1] == ':') {
 		optarg = &argv[optind][2];
 		if (optarg[0] == 0)
-			optarg = NULL;
+			return '?';
 	}
 
 	optind++;


### PR DESCRIPTION
1. 
Timestamping code is refactored.
It no longer displays fractions of microseconds.

2. 
Don't accept space between an option and its value. 