### PR TITLE
Fixes: Timestamp refactor, default address for Windows client & Custom optget

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ On NODE1 (the receiver), run:
 
 On NODE2 (the sender), run:
 ```
-./lagscope -s192.168.4.1 -H -a 10 -l 1 -c 98
+./lagscope -s192.168.4.1 -H -a10 -l1 -c98
 ```
 (Translation: Run lagscope as a sender, with default test settings; report histogram value with customized factors.)
 
@@ -71,7 +71,7 @@ On NODE2 (the sender), run:
 Example sender-side output from a given run:
 
 ```
-simonxiao@NODE2:~/lagscope/src# ./lagscope -s192.168.4.1 -H -a 10 -l 1 -c 98
+simonxiao@NODE2:~/lagscope/src# ./lagscope -s192.168.4.1 -H -a10 -l1 -c98
 lagscope 0.1.1
 ---------------------------------------------------------
 13:19:44 INFO: New connection: local:13948 [socket:3] --> 192.168.4.1:6001

--- a/src/common.h
+++ b/src/common.h
@@ -38,7 +38,6 @@
 #define WSACLEAN() WSACleanup()
 #define SLEEP(t) Sleep(t*1000)
 #define run_test_timer(duration) SetTimer(NULL, 0, duration*1000, (TIMERPROC) timer_fired)
-int gettimeofday(struct timeval * tp, struct timezone * tzp);
 int asprintf(char **strp, const char *format, ...);
 char* optarg;
 int getopt(int argc, char *const argv[], const char *optstr);

--- a/src/common.h
+++ b/src/common.h
@@ -21,7 +21,6 @@
 #include <pthread.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <getopt.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -39,8 +38,6 @@
 #define SLEEP(t) Sleep(t*1000)
 #define run_test_timer(duration) SetTimer(NULL, 0, duration*1000, (TIMERPROC) timer_fired)
 int asprintf(char **strp, const char *format, ...);
-char* optarg;
-int getopt(int argc, char *const argv[], const char *optstr);
 #else
 #define INIT_SOCKFD_VAR() int sockfd = 0
 #define CLOSE(s) close(s)

--- a/src/lagscope.h
+++ b/src/lagscope.h
@@ -64,8 +64,8 @@ struct lagscope_test_client{
 
 struct lagscope_test_runtime{
 	struct lagscope_test *test;
-	struct timeval start_time;
-	struct timeval current_time;
+	long long start_time;
+	long long current_time;
 	unsigned long  ping_elapsed;
 
 	unsigned long lazy_prog_report_factor;

--- a/src/lin_utils.c
+++ b/src/lin_utils.c
@@ -2,6 +2,19 @@
 #include "controller.h"
 
 #ifndef _WIN32
+long long time_in_nanosec(void)
+{
+	long ns;
+	time_t sec;
+	struct timespec spec;
+
+	clock_gettime(CLOCK_REALTIME, &spec);
+	sec = spec.tv_sec;
+	ns = spec.tv_nsec;
+
+	return (sec * 1000000000L + ns);
+}
+
 void run_test_timer(int duration)
 {
 	struct itimerval it_val;

--- a/src/main.c
+++ b/src/main.c
@@ -53,17 +53,14 @@ long run_lagscope_sender(struct lagscope_test_client *client)
 	char *port_str; //to get remote peer's port number for getaddrinfo()
 	struct addrinfo hints, *serv_info, *p; //to get remote peer's sockaddr for connect()
 
-	struct timeval now;
-	struct timeval send_time;
-	struct timeval recv_time;
-	double latency = 0;
+	long long send_time, recv_time, latency = 0;
 	int i = 0;
 
 	/* for ping statistics */
 	unsigned long n_pings = 0; //number of pings
-	double max_latency = 0;
-	double min_latency = 60000; //60 seconds
-	double sum_latency = 0;
+	long long max_latency = 0;
+	long long min_latency = 60000; //60 seconds
+	long long sum_latency = 0;
 
 	int latencies_stats_err_check = 0;
 
@@ -197,8 +194,7 @@ long run_lagscope_sender(struct lagscope_test_client *client)
 	if (test->test_mode == TIME_DURATION)
 		run_test_timer(test->duration);
 
-	gettimeofday(&now, NULL);
-	test_runtime->start_time = now;
+	test_runtime->start_time = time_in_nanosec();
 
 	/* Interop with latte.exe:
 	 * First send control byte */
@@ -213,23 +209,21 @@ long run_lagscope_sender(struct lagscope_test_client *client)
 		buffer[1] = (n_pings >> 8);
 		buffer[0] = (n_pings /*>> 0*/);
 
-		gettimeofday(&now, NULL);
-		send_time = now;
+		send_time = time_in_nanosec();
 
 		if ((n = n_write_read(sockfd, buffer, msg_actual_size)) < 0)
 			goto finished;
 
-		gettimeofday(&now, NULL);
-		recv_time = now;
+		recv_time = time_in_nanosec();
 
-		latency = get_time_diff(&recv_time, &send_time) * 1000 * 1000;
+		latency = recv_time - send_time;
 
 		push(latency);		// Push latency onto linked list
 
 		ASPRINTF(&log, "Reply from %s: bytes=%d time=%.3fus",
 				ip_address_str,
 				n,
-				latency);
+				(double) (latency/1000.0));
 		PRINT_DBG_FREE(log);
 
 		n_pings++;
@@ -264,9 +258,9 @@ finished:
 	PRINT_INFO_FREE(log);
 	if (n_pings > 0) {
 		ASPRINTF(&log, "\t  Minimum = %.3fus, Maximum = %.3fus, Average = %.3fus",
-			min_latency,
-			max_latency,
-			sum_latency/n_pings);
+			(double) (min_latency/1000.0),
+			(double) (max_latency/1000.0),
+			(double) (sum_latency/1000.0) / n_pings);
 		PRINT_INFO_FREE(log);
 	}
 

--- a/src/util.c
+++ b/src/util.c
@@ -96,14 +96,16 @@ void print_usage()
 	printf("\treceiver:\n");
 	printf("\t1) ./lagscope -r\n");
 	printf("\t2) ./lagscope -r192.168.1.1\n");
-	printf("\t3) ./lagscope -r -D -f0 -6 -p 6789 -V\n");
+	printf("\t3) ./lagscope -r -D -f0 -6 -p6789 -V\n");
 	printf("\tsender:\n");
 	printf("\t1) ./lagscope -s192.168.1.1\n");
-	printf("\t2) ./lagscope -s192.168.1.1 -t 600 -i 1 -V\n");
-	printf("\t3) ./lagscope -s192.168.1.1 -n 1000 -6 -i 2 -V\n");
-	printf("\t1) ./lagscope -s192.168.1.1 -H -a 10 -l 1 -c 98\n");
+	printf("\t2) ./lagscope -s192.168.1.1 -t600 -i1 -V\n");
+	printf("\t3) ./lagscope -s192.168.1.1 -n1000 -6 -i2 -V\n");
+	printf("\t1) ./lagscope -s192.168.1.1 -H -a10 -l1 -c98\n");
 	printf("\t1) ./lagscope -s192.168.1.1 -Pfreq_table.json\n");
 	printf("\t1) ./lagscope -s192.168.1.1 -Rraw_latency_values.csv\n");
+
+	printf("\nNote: There should be no space between option and its value\n");
 }
 
 void print_version()

--- a/src/util.c
+++ b/src/util.c
@@ -201,22 +201,58 @@ int verify_args(struct lagscope_test *test)
 	return NO_ERR;
 }
 
+// This is a custom getopt common for both Windows & Linux
+// This don't accept space between option and its value
+char* optarg2 = NULL;
+int getopt2(int argc, char *const argv[], const char *optstr)
+{
+	static int optind = 1;
+
+	if ((optind >= argc) || (argv[optind][0] == 0))
+		return -1;
+
+	if (argv[optind][0] != '-')
+		return '?';
+
+	int opt = argv[optind][1];
+	const char *p = strchr(optstr, opt);
+
+	if (p == NULL)
+		return '?';
+
+	optarg2 = &argv[optind][2];
+
+	if (p[1] == ':') {
+		if (p[2] != ':') {
+			if (optarg2[0] == 0)
+				return '?';
+		}
+		if (p[2] == ':') {
+			if (optarg2[0] == 0)
+				optarg2 = NULL;
+		}
+	}
+
+	optind++;
+	return opt;
+}
+
 int parse_arguments(struct lagscope_test *test, int argc, char **argv)
 {
 	int flag;
 
-	while ((flag = getopt(argc, argv, "r::s::Df:6up:b:B:z:t:n:i:R::P::Ha:l:c:Vh")) != -1) {
+	while ((flag = getopt2(argc, argv, "r::s::Df:6up:b:B:z:t:n:i:R::P::Ha:l:c:Vh")) != -1) {
 		switch (flag) {
 		case 'r':
 			test->server_role = true;
-			if (optarg)
-				test->bind_address = optarg;
+			if (optarg2)
+				test->bind_address = optarg2;
 			break;
 
 		case 's':
 			test->client_role = true;
-			if (optarg)
-				test->bind_address = optarg;
+			if (optarg2)
+				test->bind_address = optarg2;
 			break;
 
 		case 'D':
@@ -224,7 +260,7 @@ int parse_arguments(struct lagscope_test *test, int argc, char **argv)
 			break;
 
 		case 'f':
-			test->cpu_affinity = atoi(optarg);
+			test->cpu_affinity = atoi(optarg2);
 			break;
 
 		case '6':
@@ -236,32 +272,32 @@ int parse_arguments(struct lagscope_test *test, int argc, char **argv)
 			break;
 
 		case 'p':
-			test->server_port = atoi(optarg);
+			test->server_port = atoi(optarg2);
 			break;
 
 		case 'b':
-			test->recv_buf_size = unit_atod(optarg);
+			test->recv_buf_size = unit_atod(optarg2);
 			break;
 
 		case 'B':
-			test->send_buf_size = unit_atod(optarg);
+			test->send_buf_size = unit_atod(optarg2);
 			break;
 
 		case 'z':
-			test->msg_size = atoi(optarg);
+			test->msg_size = atoi(optarg2);
 			break;
 
 		case 't':
-			test->duration = atoi(optarg);
+			test->duration = atoi(optarg2);
 			test->test_mode = TIME_DURATION;
 			break;
 
 		case 'n':
-			test->iteration = atoi(optarg);
+			test->iteration = atoi(optarg2);
 			break;
 
 		case 'i':
-			test->interval = atoi(optarg);
+			test->interval = atoi(optarg2);
 			break;
 
 		case 'H':
@@ -269,15 +305,15 @@ int parse_arguments(struct lagscope_test *test, int argc, char **argv)
 			break;
 
 		case 'a':
-			test->hist_start = atoi(optarg);
+			test->hist_start = atoi(optarg2);
 			break;
 
 		case 'l':
-			test->hist_len = atoi(optarg);
+			test->hist_len = atoi(optarg2);
 			break;
 
 		case 'c':
-			test->hist_count = atoi(optarg);
+			test->hist_count = atoi(optarg2);
 			break;
 
 		case 'V':
@@ -286,17 +322,17 @@ int parse_arguments(struct lagscope_test *test, int argc, char **argv)
 
 		case 'P':
 			test->perc = true;
-			if(optarg)
+			if(optarg2)
 			{
 				test->freq_table_dump = true;
-				test->json_file_name = optarg;
+				test->json_file_name = optarg2;
 			}
 			break;
 
 		case 'R':
 			test->raw_dump = true;
-			if(optarg)
-				test->csv_file_name = optarg;
+			if(optarg2)
+				test->csv_file_name = optarg2;
 			break;
 
 		case 'h':

--- a/src/util.c
+++ b/src/util.c
@@ -158,6 +158,10 @@ int verify_args(struct lagscope_test *test)
 	}
 
 	if (test->client_role) {
+		if (0 == strcmp(test->bind_address, "0.0.0.0")) {
+			// This is needed due to behaviour if Win socket in client mode
+			test->bind_address = "127.0.0.1";
+		}
 		if (test->hist_start < 0) {
 			PRINT_ERR("histogram interval start value provided is invalid; use default value.");
 			test->hist_start = HIST_DEFAULT_START_AT;

--- a/src/util.h
+++ b/src/util.h
@@ -31,10 +31,7 @@ void latencies_stats_cleanup(void);
 double unit_atod(const char *s);
 char *retrive_ip_address_str(struct sockaddr_storage *ss, char *ip_str, size_t maxlen);
 
-static inline double get_time_diff(struct timeval *t1, struct timeval *t2)
-{
-	return fabs((t1->tv_sec + (t1->tv_usec / 1000000.0)) - (t2->tv_sec + (t2->tv_usec / 1000000.0)));
-}
+long long time_in_nanosec(void);
 
 static inline void report_progress(struct lagscope_test_runtime *test_runtime)
 {
@@ -51,10 +48,10 @@ static inline void report_progress(struct lagscope_test_runtime *test_runtime)
 		test_runtime->ping_elapsed * 100 / test_runtime->test->iteration);
 	}
 	else {
-		double time_elapsed = get_time_diff(&test_runtime->current_time, &test_runtime->start_time);
+		double time_elapsed = test_runtime->current_time - test_runtime->start_time;
 		printf("%s: %.0f%% completed.\r",
 		test_runtime->test->bind_address,
-		time_elapsed * 100 / test_runtime->test->duration);
+		time_elapsed / 10000000 / test_runtime->test->duration);
 	}
 	fflush(stdout);
 }

--- a/src/win_utils.c
+++ b/src/win_utils.c
@@ -1,41 +1,6 @@
 #include "common.h"
 
 #ifdef _WIN32
-char* optarg = NULL;
-
-int getopt(int argc, char *const argv[], const char *optstr)
-{
-	static int optind = 1;
-
-	if ((optind >= argc) || (argv[optind][0] == 0))
-		return -1;
-
-	if (argv[optind][0] != '-')
-		return '?';
-
-	int opt = argv[optind][1];
-	const char *p = strchr(optstr, opt);
-
-	if (p == NULL)
-		return '?';
-
-	optarg = &argv[optind][2];
-
-	if (p[1] == ':') {
-		if (p[2] != ':') {
-			if (optarg[0] == 0)
-				return '?';
-		}
-		if (p[2] == ':') {
-			if (optarg[0] == 0)
-				optarg = NULL;
-		}
-	}
-
-	optind++;
-	return opt;
-}
-
 long long time_in_nanosec(void)
 {
 	LARGE_INTEGER Time, Frequency;

--- a/src/win_utils.c
+++ b/src/win_utils.c
@@ -7,8 +7,11 @@ int getopt(int argc, char *const argv[], const char *optstr)
 {
 	static int optind = 1;
 
-	if ((optind >= argc) || (argv[optind][0] != '-') || (argv[optind][0] == 0))
+	if ((optind >= argc) || (argv[optind][0] == 0))
 		return -1;
+
+	if (argv[optind][0] != '-')
+		return '?';
 
 	int opt = argv[optind][1];
 	const char *p = strchr(optstr, opt);
@@ -16,10 +19,17 @@ int getopt(int argc, char *const argv[], const char *optstr)
 	if (p == NULL)
 		return '?';
 
+	optarg = &argv[optind][2];
+
 	if (p[1] == ':') {
-		optarg = &argv[optind][2];
-		if (optarg[0] == 0)
-			optarg = NULL;
+		if (p[2] != ':') {
+			if (optarg[0] == 0)
+				return '?';
+		}
+		if (p[2] == ':') {
+			if (optarg[0] == 0)
+				optarg = NULL;
+		}
 	}
 
 	optind++;

--- a/src/win_utils.c
+++ b/src/win_utils.c
@@ -26,22 +26,14 @@ int getopt(int argc, char *const argv[], const char *optstr)
 	return opt;
 }
 
-int gettimeofday(struct timeval * tp, struct timezone * tzp)
+long long time_in_nanosec(void)
 {
-	static const uint64_t EPOCH = ((uint64_t) 116444736000000000ULL);
+	LARGE_INTEGER Time, Frequency;
 
-	SYSTEMTIME  system_time;
-	FILETIME    file_time;
-	uint64_t    time;
+	QueryPerformanceFrequency(&Frequency);
+	QueryPerformanceCounter(&Time);
 
-	GetSystemTime( &system_time );
-	SystemTimeToFileTime( &system_time, &file_time );
-	time =  ((uint64_t)file_time.dwLowDateTime );
-	time += ((uint64_t)file_time.dwHighDateTime) << 32;
-
-	tp->tv_sec  = (long) ((time - EPOCH) / 10000000L);
-	tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
-        return 0;
+	return (Time.QuadPart * 1000000000I64 / Frequency.QuadPart);
 }
 
 static int vasprintf(char **strp, const char *format, va_list ap)


### PR DESCRIPTION
1. Refactor time stamping code to use nano second resolution. This fixes minimum latency=0 issue seen on Windows.
2. Use "127.0.0.1" for default address in client mode. "0.0.0.0" doesn't work in client mode in Windows win sockets.
3. Use the custom getopt for both Linux and Windows to get same behaviour. It doesn't accept space between option and its value.