### PR TITLE
Remove 'possible data loss' warnings suppression

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -66,7 +66,6 @@ void run_test_timer(int duration);
 #pragma comment (lib, "AdvApi32.lib")
 
 // Todo: Fix these warnings instead of suppress
-#pragma warning(disable : 4244) // Possible data loss due to conversion
 #pragma warning(disable : 4996) // Unsecure function in use
 
 #endif // _WIN32

--- a/src/lagscope.c
+++ b/src/lagscope.c
@@ -91,10 +91,8 @@ struct lagscope_test_runtime *new_test_runtime(struct lagscope_test *test)
 	/* calculate the lazy_prog_report_factor */
 	unsigned long total_pings = 1;
 	/*
-	 * For PING_ITERATION, we know the total number of pings will be executed;
-	 * For TIME_DURATION, we estimate the total number of pings:
-	 *   a) total test duration time, divided by
-	 *   b) interval between each pings, or 1 ms (0.001 sec) if the interval == 0.
+	 * For PING_ITERATION, we know the total number of pings to be executed.
+	 * For TIME_DURATION, we estimate the total number of pings.
 	 */
 	if (test->test_mode == PING_ITERATION) {
 		total_pings = test->iteration;
@@ -103,7 +101,7 @@ struct lagscope_test_runtime *new_test_runtime(struct lagscope_test *test)
 		if (test->interval !=0)
 			total_pings = test->duration / test->interval;
 		else
-			total_pings = test->duration / 0.001;
+			total_pings = test->duration * 1000;
 	}
 	/*
 	 * We report the percentage of test progress.

--- a/src/lagscope.h
+++ b/src/lagscope.h
@@ -21,8 +21,8 @@ struct lagscope_test
 	int     domain;              /* default for AF_INET, or '-6' for AF_INET6 */
 	int     protocol;            /* default for SOCK_STREAM for TCP, or '-u' for SOCK_DGRAM for UDP (does not support UDP for now) */
 	unsigned int    server_port; /* '-p' for server listening base port */
-	double  recv_buf_size;       /* '-b' for receive buffer option */
-	double  send_buf_size;       /* '-B' for send buffer option */
+	int  recv_buf_size;       /* '-b' for receive buffer option */
+	int  send_buf_size;       /* '-B' for send buffer option */
 
 	/* client-only parameters */
 	int     test_mode;           /* lagscope client will decide a test mode based on user input */

--- a/src/main.c
+++ b/src/main.c
@@ -205,10 +205,10 @@ long run_lagscope_sender(struct lagscope_test_client *client)
 	while (is_light_turned_on()) {
 		/* Interop with latte.exe:
 		 * latte needs iteration count in data */
-		buffer[3] = (n_pings >> 24);
-		buffer[2] = (n_pings >> 16);
-		buffer[1] = (n_pings >> 8);
-		buffer[0] = (n_pings /*>> 0*/);
+		buffer[3] = (char)(n_pings >> 24);
+		buffer[2] = (char)(n_pings >> 16);
+		buffer[1] = (char)(n_pings >> 8);
+		buffer[0] = (char)(n_pings /*>> 0*/);
 
 		send_time_ns = time_in_nanosec();
 

--- a/src/util.c
+++ b/src/util.c
@@ -33,8 +33,8 @@ void print_flags(struct lagscope_test *test)
 		printf("%s:\t\t\t %s\n", "protocol", "UDP(*not supported yet*)");
 
 	printf("%s:\t\t\t %d\n", "server port", test->server_port);
-	printf("%s:\t %.2f\n", "socket receive buffer (bytes)", test->recv_buf_size);
-	printf("%s:\t %.2f\n", "socket send buffer (bytes)", test->send_buf_size);
+	printf("%s:\t %d\n", "socket rx buffer size (bytes)", test->recv_buf_size);
+	printf("%s:\t %d\n", "socket tx buffer size (bytes)", test->send_buf_size);
 	printf("%s:\t\t %d\n", "message size (bytes)", test->msg_size);
 
 	if (test->client_role) {
@@ -276,11 +276,11 @@ int parse_arguments(struct lagscope_test *test, int argc, char **argv)
 			break;
 
 		case 'b':
-			test->recv_buf_size = unit_atod(optarg2);
+			test->recv_buf_size = atoi(optarg2);
 			break;
 
 		case 'B':
-			test->send_buf_size = unit_atod(optarg2);
+			test->send_buf_size = atoi(optarg2);
 			break;
 
 		case 'z':
@@ -353,39 +353,6 @@ void print_test_stats()
 {
 	PRINT_INFO("TBD");
 }
-
-const long KIBI = 1<<10;
-const long MEBI = 1<<20;
-const long GIBI = 1<<30;
-double unit_atod(const char *s)
-{
-	double n;
-	char suffix = '\0';
-
-	sscanf(s, "%lf%c", &n, &suffix);
-	switch (suffix) {
-	case 'g': case 'G':
-		n *= GIBI;
-		break;
-	case 'm': case 'M':
-		n *= MEBI;
-		break;
-	case 'k': case 'K':
-		n *= KIBI;
-		break;
-	default:
-		break;
-	}
-	return n;
-}
-
-const char *unit_bps[] =
-{
-	"bps",
-	"Kbps",
-	"Mbps",
-	"Gbps"
-};
 
 char *retrive_ip_address_str(struct sockaddr_storage *ss, char *ip_str, size_t maxlen)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -28,7 +28,6 @@ void create_freq_table_json(unsigned long, const char *);
 void push(unsigned long);
 void latencies_stats_cleanup(void);
 
-double unit_atod(const char *s);
 char *retrive_ip_address_str(struct sockaddr_storage *ss, char *ip_str, size_t maxlen);
 
 long long time_in_nanosec(void);
@@ -48,8 +47,8 @@ static inline void report_progress(struct lagscope_test_runtime *test_runtime)
 		test_runtime->ping_elapsed * 100 / test_runtime->test->iteration);
 	}
 	else {
-		double time_elapsed = test_runtime->current_time - test_runtime->start_time;
-		printf("%s: %.0f%% completed.\r",
+		long long time_elapsed = test_runtime->current_time - test_runtime->start_time;
+		printf("%s: %lld%% completed.\r",
 		test_runtime->test->bind_address,
 		time_elapsed / 10000000 / test_runtime->test->duration);
 	}


### PR DESCRIPTION
fixed many warnings then removed warnings suppression.

But following two warnings remain...

main.c
C:\Users\v-santy\lagscope\src\main.c(222): warning C4244: 'function': conversion from 'double' to 'unsigned long', possible loss of data
C:\Users\v-santy\lagscope\src\main.c(276): warning C4244: 'function': conversion from 'double' to 'unsigned long', possible loss of data

These remaining warnings will be addressed later.
