### PR TITLE
Fix cmake version compatibility warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project (Lagscope C)
 file(GLOB CSources *.c)
 add_executable(lagscope ${CSources})


### PR DESCRIPTION
This fixes warning:

c:\Users\sayadawa\OneDrive - Microsoft\Desktop\lagscope>do-cmake.bat
build
-- Building for: Visual Studio 16 2019
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
Compatibility with CMake < 2.8.12 will be removed from a future version of CMake.