### PR TITLE
Fix negative latency issue on Windows (issue #40)

### DIFF
--- a/src/lagscope.h
+++ b/src/lagscope.h
@@ -66,8 +66,8 @@ struct lagscope_test_client{
 
 struct lagscope_test_runtime{
 	struct lagscope_test *test;
-	long long start_time;
-	long long current_time;
+	double start_time;
+	double current_time;
 	unsigned long  ping_elapsed;
 
 	unsigned long lazy_prog_report_factor;

--- a/src/lin_utils.c
+++ b/src/lin_utils.c
@@ -2,7 +2,7 @@
 #include "controller.h"
 
 #ifndef _WIN32
-long long time_in_nanosec(void)
+double time_in_usec(void)
 {
 	long ns;
 	time_t sec;
@@ -12,7 +12,7 @@ long long time_in_nanosec(void)
 	sec = spec.tv_sec;
 	ns = spec.tv_nsec;
 
-	return (sec * 1000000000L + ns);
+	return (sec * 1000000 + ns / 1000.0);
 }
 
 void run_test_timer(int duration)

--- a/src/main.c
+++ b/src/main.c
@@ -53,7 +53,7 @@ long run_lagscope_sender(struct lagscope_test_client *client)
 	char *port_str; //to get remote peer's port number for getaddrinfo()
 	struct addrinfo hints, *serv_info, *p; //to get remote peer's sockaddr for connect()
 
-	long long send_time_ns, recv_time_ns = 0;
+	double send_time_us, recv_time_us = 0.0;
 	double latency_ms = 0.0;
 	int i = 0;
 	int ret = 0; //hold function return value
@@ -200,7 +200,7 @@ long run_lagscope_sender(struct lagscope_test_client *client)
 	if (test->test_mode == TIME_DURATION)
 		run_test_timer(test->duration);
 
-	test_runtime->start_time = time_in_nanosec();
+	test_runtime->start_time = time_in_usec();
 
 	/* Interop with latte.exe:
 	 * First send control byte */
@@ -215,14 +215,14 @@ long run_lagscope_sender(struct lagscope_test_client *client)
 		buffer[1] = (char)(n_pings >> 8);
 		buffer[0] = (char)(n_pings /*>> 0*/);
 
-		send_time_ns = time_in_nanosec();
+		send_time_us = time_in_usec();
 
 		if ((n = n_write_read(sockfd, buffer, msg_actual_size)) < 0)
 			goto finished;
 
-		recv_time_ns = time_in_nanosec();
+		recv_time_us = time_in_usec();
 
-		latency_ms = (double) ((recv_time_ns - send_time_ns)/1000.0);
+		latency_ms = recv_time_us - send_time_us;
 
 		push(latency_ms);		// Push latency onto linked list
 
@@ -233,7 +233,7 @@ long run_lagscope_sender(struct lagscope_test_client *client)
 		PRINT_DBG_FREE(log);
 
 		n_pings++;
-		test_runtime->current_time = recv_time_ns;
+		test_runtime->current_time = recv_time_us;
 		test_runtime->ping_elapsed = n_pings;
 
 		/* calculate max. avg. min. */

--- a/src/util.h
+++ b/src/util.h
@@ -30,7 +30,7 @@ void latencies_stats_cleanup(void);
 
 char *retrive_ip_address_str(struct sockaddr_storage *ss, char *ip_str, size_t maxlen);
 
-long long time_in_nanosec(void);
+double time_in_usec(void);
 int set_affinity(int cpuid);
 void run_test_timer(int duration);
 
@@ -49,10 +49,10 @@ static inline void report_progress(struct lagscope_test_runtime *test_runtime)
 		test_runtime->ping_elapsed * 100 / test_runtime->test->iteration);
 	}
 	else {
-		long long time_elapsed = test_runtime->current_time - test_runtime->start_time;
-		printf("%s: %lld%% completed.\r",
+		double time_elapsed = test_runtime->current_time - test_runtime->start_time;
+		printf("%s: %.0f%% completed.\r",
 		test_runtime->test->bind_address,
-		time_elapsed / 10000000 / test_runtime->test->duration);
+		time_elapsed / 10000 / test_runtime->test->duration);
 	}
 	fflush(stdout);
 }

--- a/src/win_utils.c
+++ b/src/win_utils.c
@@ -18,14 +18,14 @@ void run_test_timer(int duration)
 	_beginthread(timer_thread, 0, NULL);
 }
 
-long long time_in_nanosec(void)
+double time_in_usec(void)
 {
 	LARGE_INTEGER Time, Frequency;
 
 	QueryPerformanceFrequency(&Frequency);
 	QueryPerformanceCounter(&Time);
 
-	return (Time.QuadPart * 1000000000I64 / Frequency.QuadPart);
+	return ((Time.QuadPart * 1000000)/Frequency.QuadPart);
 }
 
 static int vasprintf(char **strp, const char *format, va_list ap)


### PR DESCRIPTION
This hunk is the main fix for the issue:
	-       return (Time.QuadPart * 1000000000I64 / Frequency.QuadPart);
	+       return ((Time.QuadPart * 1000000)/Frequency.QuadPart);