### PR TITLE
Add 95th,99th percentile of latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ On NODE2 (the sender), run:
 ```
 ./lagscope -s192.168.4.1 -P
 ```
-(Translation: Run lagscope as a sender. Prints these percentiles of the latencies: 50%, 75%, 90%, 99%, 99.9%, 99.99%, 99.999%.)
+(Translation: Run lagscope as a sender. Prints these percentiles of the latencies: 50%, 75%, 90%, 95%, 99%, 99.9%, 99.99%, 99.999%.)
 
 Option for dumping the latency frequency table into a JSON file, run:
 ```
@@ -140,6 +140,8 @@ Percentile       Latency(us)
      50%         80
      75%         102
      90%         113
+     95%         142
+     99%         210
    99.9%         410
   99.99%         2566
  99.999%         3921
@@ -159,6 +161,8 @@ Percentile       Latency(us)
      50%         80
      75%         102
      90%         113
+     95%         142
+     99%         210
    99.9%         410
   99.99%         2566
  99.999%         3921

--- a/src/latencies_stats.c
+++ b/src/latencies_stats.c
@@ -76,7 +76,7 @@ int process_latencies(unsigned long max_latency)
 int show_percentile(unsigned long max_latency, unsigned long n_pings)
 {
     unsigned int i = 0;
-    double percentile_array[] = {50, 75, 90, 99.9, 99.99, 99.999};
+    double percentile_array[] = {50, 75, 90, 95, 99, 99.9, 99.99, 99.999};
     size_t percentile_array_size = sizeof(percentile_array) / sizeof(percentile_array[0]);
     int percentile_idx = 0;
 

--- a/src/util.c
+++ b/src/util.c
@@ -92,7 +92,7 @@ void print_usage()
 	printf("\t-a   [SENDER ONLY] histogram 1st interval start value	[default: %d]\n", HIST_DEFAULT_START_AT);
 	printf("\t-l   [SENDER ONLY] length of histogram intervals	[default: %d]\n", HIST_DEFAULT_INTERVAL_LEN);
 	printf("\t-c   [SENDER ONLY] count of histogram intervals\t	[default: %d] [max: %d]\n", HIST_DEFAULT_INTERVAL_COUNT, HIST_MAX_INTERVAL_COUNT_USER);
-	printf("\t-P   [SENDER ONLY] prints 50th, 75th, 90th, 99th, 99.9th, 99.99th, 99.999th percentile of latencies\n");
+	printf("\t-P   [SENDER ONLY] prints 50th, 75th, 90th, 95th, 99th, 99.9th, 99.99th, 99.999th percentile of latencies\n");
 	printf("\t     Dump latency frequency table to a json file if specified after '-P'\n");
 
 	printf("\t-V   Verbose mode\n");


### PR DESCRIPTION
Some performance metrics need P95, P99 results, so we add these two percentile.
The result is like this:
```
lagscope 1.0.1
---------------------------------------------------------
01:13:21 INFO: New connection: local:25001 [socket:3] --> 10.0.0.4:6001
01:13:26 INFO: TEST COMPLETED.
01:13:26 INFO: Ping statistics for 10.0.0.4:
01:13:26 INFO:    Number of successful Pings: 100000
01:13:26 INFO:    Minimum = 35.500us, Maximum = 6997.250us, Average = 47.863us

Percentile       Latency(us)
     50%         39
     75%         44
     90%         57
     95%         78
     99%         148
   99.9%         530
  99.99%         2813
 99.999%         5080
```
